### PR TITLE
Improve test suite stability

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,7 +5,7 @@ name: Unit tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ "**" ]
   pull_request:
     branches: [ main ]
 

--- a/w4af/core/controllers/plugins/tests/test_audit_plugin.py
+++ b/w4af/core/controllers/plugins/tests/test_audit_plugin.py
@@ -36,12 +36,12 @@ from w4af.core.controllers.w4afCore import w4afCore
 class TestAuditPlugin(unittest.TestCase):
 
     def setUp(self):
-        kb.cleanup()
+        kb.cleanup(ignore_errors=True)
         self.w4af = w4afCore()
 
     def tearDown(self):
         self.w4af.quit()
-        kb.cleanup()
+        kb.cleanup(ignore_errors=True)
     
     def test_audit_return_vulns(self):
         plugin_inst = self.w4af.plugins.get_plugin_inst('audit', 'sqli')

--- a/w4af/core/controllers/tests/core_test_suite/test_core_exceptions.py
+++ b/w4af/core/controllers/tests/core_test_suite/test_core_exceptions.py
@@ -31,6 +31,7 @@ from w4af.core.controllers.exceptions import (ScanMustStopException,
                                               ScanMustStopByUnknownReasonExc,
                                               ScanMustStopByUserRequest)
 from w4af.plugins.tests.helper import create_target_option_list
+from w4af.core.data.kb.knowledge_base import kb
 
 
 @pytest.mark.moth
@@ -49,6 +50,7 @@ class TestCoreExceptions(unittest.TestCase):
 
         In the tearDown method, I'll remove the file.
         """
+        kb.cleanup(ignore_errors=True)
         self.w4afcore = w4afCore()
         
         target_opts = create_target_option_list(URL(get_moth_http()))
@@ -68,6 +70,7 @@ class TestCoreExceptions(unittest.TestCase):
     
     def tearDown(self):
         self.w4afcore.quit()
+        kb.cleanup(ignore_errors=True)
                         
     def test_stop_on_must_stop_exception(self):
         """

--- a/w4af/core/controllers/w4afCore.py
+++ b/w4af/core/controllers/w4afCore.py
@@ -545,7 +545,7 @@ class w4afCore(object):
         This method is called when the process ends normally or by an error.
         """
         stop_profiling(self)
-        parser_cache.dpc.clear()
+        parser_cache.dpc.clear(ignore_errors=True)
 
         try:
             #

--- a/w4af/core/controllers/w4afCore.py
+++ b/w4af/core/controllers/w4afCore.py
@@ -396,7 +396,7 @@ class w4afCore(object):
             om.out.error(msg + ": " + e.message)
 
         # Stop the parser subprocess
-        parser_cache.dpc.clear()
+        parser_cache.dpc.clear(ignore_errors=True)
 
         # Remove the xurllib cache, bloom filters, DiskLists, etc.
         #
@@ -487,7 +487,7 @@ class w4afCore(object):
         remove_temp_dir(ignore_errors=True)
 
         # Stop the parser subprocess
-        parser_cache.dpc.clear()
+        parser_cache.dpc.clear(ignore_errors=True)
 
     def pause(self, pause_yes_no):
         """

--- a/w4af/core/controllers/w4afCore.py
+++ b/w4af/core/controllers/w4afCore.py
@@ -67,6 +67,7 @@ from w4af.core.controllers.exceptions import (BaseFrameworkException,
 
 from w4af.core.data.url.extended_urllib import ExtendedUrllib
 from w4af.core.data.kb.knowledge_base import kb
+from w4af.core.data.db.dbms import DBMSException
 
 
 NO_MEMORY_MSG = ('The operating system was unable to allocate memory for'
@@ -388,7 +389,11 @@ class w4afCore(object):
         self.exception_handler.clear()
         
         # Clean all data that is stored in the kb
-        kb.cleanup()
+        try:
+            kb.cleanup()
+        except DBMSException as e:
+            msg = "Exception trying to clean up KB instance during shutdown"
+            om.out.error(msg + ": " + e.message)
 
         # Stop the parser subprocess
         parser_cache.dpc.clear()

--- a/w4af/core/data/db/dbms.py
+++ b/w4af/core/data/db/dbms.py
@@ -60,6 +60,9 @@ DB_MALFORMED_ERROR = ('SQLite raised a database disk image is malformed'
                       '[0] https://www.sqlite.org/howtocorrupt.html\n'
                       '[1] https://github.com/andresriancho/w3af/issues/4905')
 
+class DBMSException(Exception):
+    def __init__(self, message):
+        self.message = message
 
 def verify_started(meth):
     
@@ -67,7 +70,8 @@ def verify_started(meth):
     def inner_verify_started(self, *args, **kwds):
         msg = 'No calls to SQLiteDBMS can be made after stop().'
 
-        assert not self.sql_executor.get_received_poison_pill(), msg
+        if self.sql_executor.get_received_poison_pill():
+            raise DBMSException(msg)
 
         return meth(self, *args, **kwds)
     

--- a/w4af/core/data/db/disk_list.py
+++ b/w4af/core/data/db/disk_list.py
@@ -27,7 +27,8 @@ import pickle
 
 from w4af.core.data.misc.cpickle_dumps import cpickle_dumps
 from w4af.core.data.db.disk_item import DiskItem
-from w4af.core.data.db.dbms import get_default_temp_db_instance
+from w4af.core.data.db.dbms import (get_default_temp_db_instance,
+                                    DBMSException)
 from w4af.core.data.fuzzer.utils import rand_alpha
 
 # Disk list states
@@ -87,10 +88,14 @@ class DiskList(object):
 
         self._state = OPEN
 
-    def cleanup(self):
+    def cleanup(self, ignore_errors = False):
         assert self._state == OPEN
 
-        self.db.drop_table(self.table_name)
+        try:
+            self.db.drop_table(self.table_name)
+        except DBMSException as e:
+            if not ignore_errors:
+                raise e
         self._state = CLOSED
 
     def _dump(self, obj):

--- a/w4af/core/data/db/disk_list.py
+++ b/w4af/core/data/db/disk_list.py
@@ -89,7 +89,10 @@ class DiskList(object):
         self._state = OPEN
 
     def cleanup(self, ignore_errors = False):
-        assert self._state == OPEN
+        if self._state != OPEN:
+            if not ignore_errors:
+                raise DBMSException("Disk List already closed")
+            return
 
         try:
             self.db.drop_table(self.table_name)

--- a/w4af/core/data/db/disk_list.py
+++ b/w4af/core/data/db/disk_list.py
@@ -99,6 +99,9 @@ class DiskList(object):
         except DBMSException as e:
             if not ignore_errors:
                 raise e
+        except RuntimeError as e:
+            if not ignore_errors:
+                raise e
         self._state = CLOSED
 
     def _dump(self, obj):

--- a/w4af/core/data/db/tests/test_dbms.py
+++ b/w4af/core/data/db/tests/test_dbms.py
@@ -27,7 +27,9 @@ import pytest
 from itertools import repeat, starmap
 from random import choice
 
-from w4af.core.data.db.dbms import SQLiteDBMS, get_default_temp_db_instance
+from w4af.core.data.db.dbms import (SQLiteDBMS,
+                                    get_default_temp_db_instance,
+                                    DBMSException)
 from w4af.core.controllers.exceptions import DBException, NoSuchTableException
 from w4af.core.controllers.misc.temp_dir import (get_temp_dir,
                                                  create_temp_dir,
@@ -165,7 +167,7 @@ class TestDBMS(unittest.TestCase):
         db = SQLiteDBMS(get_temp_filename())
         db.close()
 
-        self.assertRaises(AssertionError, db.close)
+        self.assertRaises(DBMSException, db.close)
 
 
 class TestDefaultDB(unittest.TestCase):

--- a/w4af/core/data/db/tests/test_variant_db.py
+++ b/w4af/core/data/db/tests/test_variant_db.py
@@ -24,7 +24,8 @@ import unittest
 import pytest
 
 from w4af.core.controllers.misc_settings import MiscSettings
-from w4af.core.controllers.misc.temp_dir import create_temp_dir
+from w4af.core.controllers.misc.temp_dir import (create_temp_dir,
+                                                 remove_temp_dir)
 from w4af.core.data.dc.json_container import JSONContainer
 from w4af.core.data.fuzzer.utils import rand_alnum
 from w4af.core.data.request.fuzzable_request import FuzzableRequest
@@ -58,6 +59,7 @@ class TestVariantDB(unittest.TestCase):
     def tearDown(self):
         self.vdb.cleanup()
         reset_temp_db_instance()
+        remove_temp_dir()
 
     def test_db_int(self):
         url_fmt = 'http://w4af.net/foo.htm?id=%s'

--- a/w4af/core/data/kb/knowledge_base.py
+++ b/w4af/core/data/kb/knowledge_base.py
@@ -835,6 +835,7 @@ class DBKnowledgeBase(BasicKnowledgeBase):
         old_fuzzable_requests.cleanup(ignore_errors=ignore_errors)
 
         self.observers.clear()
+        self.initialized = False
 
     @requires_setup
     def remove(self):

--- a/w4af/core/data/kb/knowledge_base.py
+++ b/w4af/core/data/kb/knowledge_base.py
@@ -44,6 +44,7 @@ from w4af.core.data.kb.info import Info
 from w4af.core.data.kb.shell import Shell
 from w4af.core.data.kb.info_set import InfoSet
 from w4af.core.data.constants.severity import INFORMATION, LOW, MEDIUM, HIGH
+from w4af.core.data.db.dbms import DBMSException
 
 
 class BasicKnowledgeBase(object):
@@ -814,20 +815,24 @@ class DBKnowledgeBase(BasicKnowledgeBase):
         return result_dict
 
     @requires_setup
-    def cleanup(self):
+    def cleanup(self, ignore_errors = False):
         """
         Cleanup internal data.
         """
-        self.db.execute("DELETE FROM %s WHERE 1=1" % self.table_name)
+        try:
+            self.db.execute("DELETE FROM %s WHERE 1=1" % self.table_name)
+        except DBMSException as e:
+            if not ignore_errors:
+                raise e
 
         # Remove the old, create new.
         old_urls = self.urls
         self.urls = DiskSet(table_prefix='kb_urls')
-        old_urls.cleanup()
+        old_urls.cleanup(ignore_errors=ignore_errors)
 
         old_fuzzable_requests = self.fuzzable_requests
         self.fuzzable_requests = DiskSet(table_prefix='kb_fuzzable_requests')
-        old_fuzzable_requests.cleanup()
+        old_fuzzable_requests.cleanup(ignore_errors=ignore_errors)
 
         self.observers.clear()
 

--- a/w4af/core/data/kb/tests/test_knowledge_base.py
+++ b/w4af/core/data/kb/tests/test_knowledge_base.py
@@ -57,6 +57,9 @@ class TestKnowledgeBase(unittest.TestCase):
     def setUp(self):
         kb.cleanup()
 
+    def tearDown(self):
+        kb.cleanup()
+
     def test_basic(self):
         kb.raw_write('a', 'b', 'c')
         data = kb.raw_read('a', 'b')

--- a/w4af/core/data/misc/tests/test_ordered_cached_queue.py
+++ b/w4af/core/data/misc/tests/test_ordered_cached_queue.py
@@ -119,7 +119,10 @@ class TestOrderedCachedQueue(unittest.TestCase):
         self.assertEqual(len(q.memory), 2)
         self.assertEqual(len(q.disk), 1)
 
-        # Get all
+        # Get all - This depends on correctly guessing how the items
+        # will be ordered when they are added to the queue. This order
+        # is determined by hashing the request, so it is not expected
+        # to be sequential on request_id
         self.assertEqual(read_fuzzable_request_parameter(q.get()), 1)
 
         self.assertEqual(len(q.memory), 1)

--- a/w4af/core/data/parsers/parser_cache.py
+++ b/w4af/core/data/parsers/parser_cache.py
@@ -29,7 +29,6 @@ from concurrent.futures import TimeoutError
 # pylint: disable=E0401
 from darts.lib.utils.lru import SynchronizedLRUDict
 # pylint: enable=E0401
-from functools import wraps
 
 import w4af.core.controllers.output_manager as om
 
@@ -46,18 +45,6 @@ from w4af.core.data.parsers.utils.response_uniq_id import (get_response_unique_i
                                                            get_body_unique_id)
 from w4af.core.data.misc.encoding import smart_unicode
 
-def needs_parser_blacklist(meth):
-
-    @wraps(meth)
-    def inner_needs_parser_blacklist(self, *args, **kwds):
-        if self._parser_blacklist is None:
-            om.out.debug("Lazy init of parser blacklist")
-            self._parser_blacklist = DiskSet()
-
-        return meth(self, *args, **kwds)
-
-    return inner_needs_parser_blacklist
-
 
 class ParserCache(CacheStats):
     """
@@ -71,16 +58,15 @@ class ParserCache(CacheStats):
 
     def __init__(self):
         super(ParserCache, self).__init__()
-        self._parser_blacklist = None
         self._reset()
 
     def _reset(self):
         self._cache = SynchronizedLRUDict(self.CACHE_SIZE)
         self._can_parse_cache = SynchronizedLRUDict(self.CACHE_SIZE * 10)
         self._parser_finished_events = {}
-        self._parser_blacklist = None
+        self._parser_blacklist = DiskSet()
 
-    def clear(self):
+    def clear(self, ignore_errors = False):
         """
         Clear all the internal variables
         :return: None
@@ -98,6 +84,7 @@ class ParserCache(CacheStats):
         # We don't need the parsers anymore
         self._cache.clear()
         self._can_parse_cache.clear()
+        self._parser_blacklist.cleanup(ignore_errors=ignore_errors)
 
     def should_cache(self, http_response):
         """
@@ -134,7 +121,6 @@ class ParserCache(CacheStats):
         self._can_parse_cache[can_parse] = can_parse
         return can_parse
 
-    @needs_parser_blacklist
     def add_to_blacklist(self, hash_string):
         """
         Add a hash_string representing an HTTP response to the blacklist,
@@ -144,7 +130,7 @@ class ParserCache(CacheStats):
         """
         self._parser_blacklist.add(hash_string)
 
-    @needs_parser_blacklist
+
     def get_document_parser_for(self, http_response, cache=True):
         """
         Get a document parser for http_response using the cache if possible
@@ -250,7 +236,6 @@ class ParserCache(CacheStats):
         msg += detail
         om.out.debug(msg % http_response.get_uri())
 
-    @needs_parser_blacklist
     def get_tags_by_filter(self, http_response, tags, yield_text=False, cache=True):
         """
         Get specific tags from http_response using the cache if possible
@@ -383,7 +368,7 @@ class ParserCache(CacheStats):
 @atexit.register
 def cleanup_pool():
     if 'dpc' in globals():
-        dpc.clear()
+        dpc.clear(ignore_errors=True)
     
 
 if is_main_process():

--- a/w4af/core/data/parsers/parser_cache.py
+++ b/w4af/core/data/parsers/parser_cache.py
@@ -174,9 +174,11 @@ class ParserCache(CacheStats):
 
         hash_string = get_response_unique_id(http_response)
 
+        # pylint: disable=E1135
         if hash_string in self._parser_blacklist:
             msg = 'Exceeded timeout while parsing "%s" in the past. Not trying again.'
             raise BaseFrameworkException(msg % http_response.get_url())
+        # pylint: enable=E1135
 
         #
         # We know that we can parse this document, lets work!
@@ -307,9 +309,11 @@ class ParserCache(CacheStats):
         args = '%r%r' % (tags, yield_text)
         hash_string = get_body_unique_id(http_response, prepend=args)
 
+        # pylint: disable=E1135
         if hash_string in self._parser_blacklist:
             self._log_return_empty(http_response, 'HTTP response is blacklisted')
             return []
+        # pylint: enable=E1135
 
         #
         # We know that we can parse this document, lets work!

--- a/w4af/core/data/parsers/parser_cache.py
+++ b/w4af/core/data/parsers/parser_cache.py
@@ -29,6 +29,7 @@ from concurrent.futures import TimeoutError
 # pylint: disable=E0401
 from darts.lib.utils.lru import SynchronizedLRUDict
 # pylint: enable=E0401
+from functools import wraps
 
 import w4af.core.controllers.output_manager as om
 
@@ -45,6 +46,17 @@ from w4af.core.data.parsers.utils.response_uniq_id import (get_response_unique_i
                                                            get_body_unique_id)
 from w4af.core.data.misc.encoding import smart_unicode
 
+def needs_parser_blacklist(meth):
+
+    @wraps(meth)
+    def inner_needs_parser_blacklist(self, *args, **kwds):
+        if self._parser_blacklist is None:
+            om.out.debug("Lazy init of parser blacklist")
+            self._parser_blacklist = DiskSet()
+
+        return meth(self, *args, **kwds)
+
+    return inner_needs_parser_blacklist
 
 class ParserCache(CacheStats):
     """
@@ -64,7 +76,7 @@ class ParserCache(CacheStats):
         self._cache = SynchronizedLRUDict(self.CACHE_SIZE)
         self._can_parse_cache = SynchronizedLRUDict(self.CACHE_SIZE * 10)
         self._parser_finished_events = {}
-        self._parser_blacklist = DiskSet()
+        self._parser_blacklist = None
 
     def clear(self, ignore_errors = False):
         """
@@ -84,7 +96,9 @@ class ParserCache(CacheStats):
         # We don't need the parsers anymore
         self._cache.clear()
         self._can_parse_cache.clear()
-        self._parser_blacklist.cleanup(ignore_errors=ignore_errors)
+        if self._parser_blacklist is not None:
+            self._parser_blacklist.cleanup(ignore_errors=ignore_errors)
+            self._parser_blacklist = None
 
     def should_cache(self, http_response):
         """
@@ -121,6 +135,7 @@ class ParserCache(CacheStats):
         self._can_parse_cache[can_parse] = can_parse
         return can_parse
 
+    @needs_parser_blacklist
     def add_to_blacklist(self, hash_string):
         """
         Add a hash_string representing an HTTP response to the blacklist,
@@ -131,6 +146,7 @@ class ParserCache(CacheStats):
         self._parser_blacklist.add(hash_string)
 
 
+    @needs_parser_blacklist
     def get_document_parser_for(self, http_response, cache=True):
         """
         Get a document parser for http_response using the cache if possible
@@ -236,6 +252,7 @@ class ParserCache(CacheStats):
         msg += detail
         om.out.debug(msg % http_response.get_uri())
 
+    @needs_parser_blacklist
     def get_tags_by_filter(self, http_response, tags, yield_text=False, cache=True):
         """
         Get specific tags from http_response using the cache if possible

--- a/w4af/core/data/url/handlers/tests/test_cache.py
+++ b/w4af/core/data/url/handlers/tests/test_cache.py
@@ -20,6 +20,7 @@ along with w4af; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 """
+import httpretty
 import urllib.request, urllib.error, urllib.parse
 import unittest
 
@@ -93,14 +94,17 @@ class TestCacheHandler(unittest.TestCase):
 
 
 class CacheIntegrationTest(unittest.TestCase):
+
+    @httpretty.activate(allow_net_connect=False)
     def test_cache_http_errors(self):
         settings = opener_settings.OpenerSettings()
         settings.build_openers()
         opener = settings.get_custom_opener()
 
-        # w4af.net currently is only a redirect to readthedocs. Therefore 301 is returned, adapt url to make test work again;
-        # TODO: replace again once we have a proper homepage
-        url = URL('http://w3af.org/foo-bar-not-exists.htm')
+        httpretty.register_uri(httpretty.GET,
+            'http://w4af.net/foo-bar-not-exists.htm',
+            body="not found", status=404)
+        url = URL('http://w4af.net/foo-bar-not-exists.htm')
         request = HTTPRequest(url, cache=False)
 
         with patch('w4af.core.data.url.handlers.cache.CacheClass') as cc_mock:

--- a/w4af/core/ui/console/tests/helper.py
+++ b/w4af/core/ui/console/tests/helper.py
@@ -60,11 +60,10 @@ class ConsoleTestHelper(unittest.TestCase):
         #sys.exit.assert_called_once_with(0)
         self.restore_sys()
         self._mock_stdout.clear()
+        kb.kb.cleanup(ignore_errors=True)
 
-        #
         # I want to make sure that we don't have *any hidden* exceptions
         # in our tests.
-        #
         if self.console is not None:
             caught_exceptions = self.console._w4af.exception_handler.get_all_exceptions()
             msg = [e.get_summary() for e in caught_exceptions]

--- a/w4af/core/ui/console/tests/helper.py
+++ b/w4af/core/ui/console/tests/helper.py
@@ -53,7 +53,7 @@ class ConsoleTestHelper(unittest.TestCase):
     OUTPUT_HTTP_FILE = 'output-w4af-unittest-http.txt'
 
     def setUp(self):
-        kb.kb.cleanup()
+        kb.kb.cleanup(ignore_errors=True)
         self.mock_sys()
 
     def tearDown(self):

--- a/w4af/plugins/attack/payloads/payloads/tests/test_kernel_version.py
+++ b/w4af/plugins/attack/payloads/payloads/tests/test_kernel_version.py
@@ -31,4 +31,5 @@ class test_kernel_version(ApachePayloadTestHelper):
     def test_kernel_version(self):
         result = exec_payload(self.shell, 'kernel_version', use_api=True)
 
-        self.assertTrue(result['kernel_version'].startswith('5.'))
+        self.assertTrue(result['kernel_version'].startswith('5.') or \
+            result['kernel_version'].startswith('6.'))

--- a/w4af/plugins/tests/audit/test_generic.py
+++ b/w4af/plugins/tests/audit/test_generic.py
@@ -45,6 +45,7 @@ class TestGenericOnly(PluginTest):
     MOCK_RESPONSES = [GenericErrorMockResponse(re.compile('.*'), body=None,
                                                method='GET', status=200)]
 
+    @pytest.mark.flaky(reruns=5)
     def test_found_generic(self):
         self._scan(self.target_url, self.CONFIG)
         

--- a/w4af/plugins/tests/auth/test_autocomplete.py
+++ b/w4af/plugins/tests/auth/test_autocomplete.py
@@ -226,7 +226,7 @@ class TestAutocompleteInvalidCredentials(PluginTest):
 class TestAutocompleteAuthenticationFailure(unittest.TestCase):
     def test_consecutive_authentication_failure(self):
         plugin = autocomplete()
-        kb.kb.cleanup()
+        kb.kb.cleanup(ignore_errors=True)
 
         for i in range(autocomplete.MAX_CONSECUTIVE_FAILED_LOGIN_COUNT - 1):
             plugin._log_debug(str(i))
@@ -256,7 +256,7 @@ class TestAutocompleteAuthenticationFailure(unittest.TestCase):
 
     def test_mixed_authentication_results(self):
         plugin = autocomplete()
-        kb.kb.cleanup()
+        kb.kb.cleanup(ignore_errors=True)
 
         for i in range(autocomplete.MAX_CONSECUTIVE_FAILED_LOGIN_COUNT):
             plugin._log_debug(str(i))
@@ -273,7 +273,7 @@ class TestAutocompleteAuthenticationFailure(unittest.TestCase):
 
     def test_mixed_authentication_results_fail_fail_success(self):
         plugin = autocomplete()
-        kb.kb.cleanup()
+        kb.kb.cleanup(ignore_errors=True)
 
         for i in range(autocomplete.MAX_CONSECUTIVE_FAILED_LOGIN_COUNT):
             plugin._log_debug(str(i))

--- a/w4af/plugins/tests/evasion/test_core_integration.py
+++ b/w4af/plugins/tests/evasion/test_core_integration.py
@@ -28,16 +28,19 @@ from w4af.core.controllers.ci.moth import get_moth_http
 from w4af.core.controllers.w4afCore import w4afCore
 from w4af.core.data.parsers.doc.url import URL
 from w4af.plugins.tests.helper import create_target_option_list
+import w4af.core.data.kb.knowledge_base as kb
 
 
 @pytest.mark.moth
 class TestCoreIntegration(unittest.TestCase):
     
     def setUp(self):
+        kb.kb.cleanup(ignore_errors=True)
         self.w4afcore = w4afCore()
 
     def tearDown(self):
         self.w4afcore.quit()
+        kb.kb.cleanup(ignore_errors=True)
             
     def test_send_mangled(self):
         

--- a/w4af/plugins/tests/grep/test_all.py
+++ b/w4af/plugins/tests/grep/test_all.py
@@ -33,6 +33,7 @@ from w4af.core.data.url.HTTPResponse import HTTPResponse
 from w4af.core.data.dc.headers import Headers
 from w4af.core.data.request.fuzzable_request import FuzzableRequest
 from w4af.core.data.parsers.doc.url import URL
+import w4af.core.data.kb.knowledge_base as kb
 
 
 class test_all(unittest.TestCase):
@@ -43,6 +44,7 @@ class test_all(unittest.TestCase):
         self.url_str = 'http://moth/'
         self.url_inst = URL(self.url_str)
 
+        kb.kb.cleanup(ignore_errors=True)
         self._w4af = w4afCore()
         self._plugins = []
         for pname in self._w4af.plugins.get_plugin_list('grep'):

--- a/w4af/plugins/tests/grep/test_analyze_cookies.py
+++ b/w4af/plugins/tests/grep/test_analyze_cookies.py
@@ -32,11 +32,12 @@ from w4af.plugins.grep.analyze_cookies import analyze_cookies
 class TestAnalyzeCookies(unittest.TestCase):
 
     def setUp(self):
-        kb.kb.cleanup()
+        kb.kb.cleanup(ignore_errors=True)
         self.plugin = analyze_cookies()
 
     def tearDown(self):
         self.plugin.end()
+        kb.kb.cleanup(ignore_errors=True)
 
     def test_analyze_cookies_negative(self):
         body = ''

--- a/w4af/plugins/tests/grep/test_code_disclosure.py
+++ b/w4af/plugins/tests/grep/test_code_disclosure.py
@@ -38,10 +38,11 @@ class TestCodeDisclosurePlugin(unittest.TestCase):
 
     def setUp(self):
         self.plugin = code_disclosure()
-        kb.kb.clear('code_disclosure', 'code_disclosure')
+        kb.kb.cleanup(ignore_errors=True)
 
     def tearDown(self):
         self.plugin.end()
+        kb.kb.cleanup(ignore_errors=True)
 
     def _build_request_response(self, body, url=None, headers=None, method=None):
         url = url or URL('http://www.w4af.com/')

--- a/w4af/plugins/tests/grep/test_expect_ct.py
+++ b/w4af/plugins/tests/grep/test_expect_ct.py
@@ -33,12 +33,13 @@ from w4af.plugins.grep.expect_ct import expect_ct
 class TestECTSecurity(unittest.TestCase):
 
     def setUp(self):
+        kb.kb.cleanup(ignore_errors=True)
         create_temp_dir()
         self.plugin = expect_ct()
 
     def tearDown(self):
         self.plugin.end()
-        kb.kb.cleanup()
+        kb.kb.cleanup(ignore_errors=True)
 
     def test_http_no_vuln(self):
         body = ''

--- a/w4af/plugins/tests/grep/test_html_comments.py
+++ b/w4af/plugins/tests/grep/test_html_comments.py
@@ -80,12 +80,13 @@ class TestHTMLCommentsIntegration(PluginTest):
 class TestHTMLCommentsUnit(unittest.TestCase):
 
     def setUp(self):
+        kb.kb.cleanup(ignore_errors=True)
         create_temp_dir()
-        kb.kb.cleanup()
         self.plugin = html_comments()
 
     def tearDown(self):
         self.plugin.end()
+        kb.kb.cleanup(ignore_errors=True)
 
     def test_html_comment(self):
         body = '<!-- secret password123 -->'

--- a/w4af/plugins/tests/grep/test_objects.py
+++ b/w4af/plugins/tests/grep/test_objects.py
@@ -32,11 +32,12 @@ from w4af.core.data.dc.headers import Headers
 class test_objects(unittest.TestCase):
 
     def setUp(self):
+        kb.kb.cleanup(ignore_errors=True)
         self.plugin = objects()
-        kb.kb.clear('objects', 'objects')
 
     def tearDown(self):
         self.plugin.end()
+        kb.kb.cleanup(ignore_errors=True)
 
     def test_object(self):
         body = """header

--- a/w4af/plugins/tests/grep/test_serialized_object.py
+++ b/w4af/plugins/tests/grep/test_serialized_object.py
@@ -44,7 +44,7 @@ SERIALIZED_PHP_OBJECTS = [
 class TestSerializedObject(unittest.TestCase):
 
     def setUp(self):
-        kb.kb.cleanup()
+        kb.kb.cleanup(ignore_errors=True)
 
         self.plugin = serialized_object()
 
@@ -54,6 +54,7 @@ class TestSerializedObject(unittest.TestCase):
 
     def tearDown(self):
         self.plugin.end()
+        kb.kb.cleanup(ignore_errors=True)
 
     def test_php_serialized_objects_query_string(self):
 

--- a/w4af/plugins/tests/grep/test_ssn.py
+++ b/w4af/plugins/tests/grep/test_ssn.py
@@ -32,7 +32,7 @@ from w4af.plugins.grep.ssn import ssn
 class test_ssn(unittest.TestCase):
 
     def setUp(self):
-        kb.kb.cleanup()
+        kb.kb.cleanup(ignore_errors=True)
         self.plugin = ssn()
         self.plugin._already_inspected = set()
         self.url = URL('http://www.w4af.com/')
@@ -40,6 +40,7 @@ class test_ssn(unittest.TestCase):
 
     def tearDown(self):
         self.plugin.end()
+        kb.kb.cleanup(ignore_errors=True)
 
     def test_ssn_empty_string(self):
         body = ''

--- a/w4af/plugins/tests/helper.py
+++ b/w4af/plugins/tests/helper.py
@@ -123,7 +123,7 @@ class PluginTest(unittest.TestCase):
         self.w4afcore.quit()
         self.kb.cleanup()
         self.assert_all_get_desc_work()
-        parser_cache.dpc.clear()
+        parser_cache.dpc.clear(ignore_errors=True)
         reset_temp_db_instance()
 
         if self.MOCK_RESPONSES:

--- a/w4af/plugins/tests/helper.py
+++ b/w4af/plugins/tests/helper.py
@@ -47,6 +47,8 @@ from w4af.core.data.parsers.doc.url import URL
 from w4af.core.data.kb.read_shell import ReadShell
 from w4af.core.data.kb.info_set import InfoSet
 from w4af.core.data.misc.encoding import smart_str
+from w4af.core.data.db.dbms import reset_temp_db_instance
+import w4af.core.data.parsers.parser_cache as parser_cache
 
 
 os.chdir(w4af_LOCAL_PATH)
@@ -76,7 +78,7 @@ class PluginTest(unittest.TestCase):
     allow_net_connect = False
 
     def setUp(self):
-        self.kb.cleanup()
+        self.kb.cleanup(ignore_errors=True)
         self.w4afcore = w4afCore()
         self.misc_settings = MiscSettings()
 
@@ -121,6 +123,8 @@ class PluginTest(unittest.TestCase):
         self.w4afcore.quit()
         self.kb.cleanup()
         self.assert_all_get_desc_work()
+        parser_cache.dpc.clear()
+        reset_temp_db_instance()
 
         if self.MOCK_RESPONSES:
             httpretty.disable()

--- a/w4af/plugins/tests/infrastructure/test_http_vs_https_dist.py
+++ b/w4af/plugins/tests/infrastructure/test_http_vs_https_dist.py
@@ -46,7 +46,10 @@ class test_http_vs_https_dist(unittest.TestCase):
                                5: ('207.46.47.14', True)}}
 
     def setUp(self):
-        kb.kb.cleanup()
+        kb.kb.cleanup(ignore_errors=True)
+
+    def tearDown(self):
+        kb.kb.cleanup(ignore_errors=True)
 
     def test_discover_override_port(self):
         plugininst = hvshsdist.http_vs_https_dist()

--- a/w4af/plugins/tests/output/test_json_file.py
+++ b/w4af/plugins/tests/output/test_json_file.py
@@ -96,4 +96,4 @@ class TestJsonOutput(PluginTest):
         except:
             pass
         finally:
-            self.kb.cleanup()
+            self.kb.cleanup(ignore_errors=True)

--- a/w4af/plugins/tests/output/test_xml_file.py
+++ b/w4af/plugins/tests/output/test_xml_file.py
@@ -112,7 +112,7 @@ class TestXMLOutput(PluginTest):
         except:
             pass
         finally:
-            self.kb.cleanup()
+            self.kb.cleanup(ignore_errors=True)
 
     def test_error_null_byte(self):
         w4af_core = w4afCore()

--- a/w4af/plugins/tests/output/test_xml_file.py
+++ b/w4af/plugins/tests/output/test_xml_file.py
@@ -131,7 +131,7 @@ class TestNoDuplicate(unittest.TestCase):
     FILENAME = 'output-unittest.xml'
     
     def setUp(self):
-        kb.kb.cleanup()
+        kb.kb.cleanup(ignore_errors=True)
         create_temp_dir()
         CachedXMLNode.create_cache_path()
         FindingsCache.create_cache_path()
@@ -142,7 +142,7 @@ class TestNoDuplicate(unittest.TestCase):
     def tearDown(self):
         remove_temp_dir()
         HistoryItem().clear()
-        kb.kb.cleanup()
+        kb.kb.cleanup(ignore_errors=True)
 
     def test_no_duplicate_vuln_reports(self):
         # The xml_file plugin had a bug where vulnerabilities were written to
@@ -330,7 +330,7 @@ class TestXMLOutputBinary(PluginTest):
         except:
             pass
         finally:
-            self.kb.cleanup()
+            self.kb.cleanup(ignore_errors=True)
 
 
 class TestXML0x0B(PluginTest):
@@ -382,7 +382,7 @@ class TestXML0x0B(PluginTest):
         except:
             pass
         finally:
-            self.kb.cleanup()
+            self.kb.cleanup(ignore_errors=True)
 
 
 class TestSpecialCharacterInURL(PluginTest):
@@ -431,7 +431,7 @@ class TestSpecialCharacterInURL(PluginTest):
         except:
             pass
         finally:
-            self.kb.cleanup()
+            self.kb.cleanup(ignore_errors=True)
 
 
 class XMLNodeGeneratorTest(unittest.TestCase):
@@ -442,7 +442,7 @@ class XMLNodeGeneratorTest(unittest.TestCase):
 
 class TestHTTPTransaction(XMLNodeGeneratorTest):
     def setUp(self):
-        kb.kb.cleanup()
+        kb.kb.cleanup(ignore_errors=True)
         create_temp_dir()
         CachedXMLNode.create_cache_path()
         FindingsCache.create_cache_path()
@@ -451,7 +451,7 @@ class TestHTTPTransaction(XMLNodeGeneratorTest):
     def tearDown(self):
         remove_temp_dir()
         HistoryItem().clear()
-        kb.kb.cleanup()
+        kb.kb.cleanup(ignore_errors=True)
 
     def test_render_simple(self):
         url = URL('http://w4af.com/a/b/c.php')
@@ -548,7 +548,7 @@ class TestHTTPTransaction(XMLNodeGeneratorTest):
 
 class TestScanInfo(XMLNodeGeneratorTest):
     def setUp(self):
-        kb.kb.cleanup()
+        kb.kb.cleanup(ignore_errors=True)
         create_temp_dir()
         CachedXMLNode.create_cache_path()
         FindingsCache.create_cache_path()
@@ -557,7 +557,7 @@ class TestScanInfo(XMLNodeGeneratorTest):
     def tearDown(self):
         remove_temp_dir()
         HistoryItem().clear()
-        kb.kb.cleanup()
+        kb.kb.cleanup(ignore_errors=True)
 
     def test_render_simple(self):
         w4af_core = w4afCore()
@@ -619,13 +619,13 @@ def clear_variable_tags(xml_string):
 
 class TestScanStatus(XMLNodeGeneratorTest):
     def setUp(self):
-        kb.kb.cleanup()
+        kb.kb.cleanup(ignore_errors=True)
         create_temp_dir()
 
     def tearDown(self):
         remove_temp_dir()
         HistoryItem().clear()
-        kb.kb.cleanup()
+        kb.kb.cleanup(ignore_errors=True)
 
     def test_render_simple(self):
         w4af_core = w4afCore()
@@ -719,7 +719,7 @@ class TestScanStatus(XMLNodeGeneratorTest):
 
 class TestFinding(XMLNodeGeneratorTest):
     def setUp(self):
-        kb.kb.cleanup()
+        kb.kb.cleanup(ignore_errors=True)
         create_temp_dir()
         CachedXMLNode.create_cache_path()
         FindingsCache.create_cache_path()
@@ -728,7 +728,7 @@ class TestFinding(XMLNodeGeneratorTest):
     def tearDown(self):
         remove_temp_dir()
         HistoryItem().clear()
-        kb.kb.cleanup()
+        kb.kb.cleanup(ignore_errors=True)
 
     def test_render_simple(self):
         _id = 2
@@ -962,7 +962,7 @@ class TestFinding(XMLNodeGeneratorTest):
 
 class TestFindingsCache(XMLNodeGeneratorTest):
     def setUp(self):
-        kb.kb.cleanup()
+        kb.kb.cleanup(ignore_errors=True)
         create_temp_dir()
         CachedXMLNode.create_cache_path()
         FindingsCache.create_cache_path()
@@ -971,7 +971,7 @@ class TestFindingsCache(XMLNodeGeneratorTest):
     def tearDown(self):
         remove_temp_dir()
         HistoryItem().clear()
-        kb.kb.cleanup()
+        kb.kb.cleanup(ignore_errors=True)
 
     def test_cache_works_as_expected(self):
         #


### PR DESCRIPTION
Fix some problems with tidying up resources after test runs. There is contention between the threads doing the work, and the lifecycle management for objects that use the SQLExecutor thread during their cleanup.