### PR TITLE
debug

### DIFF
--- a/w4af/core/ui/console/plugins.py
+++ b/w4af/core/ui/console/plugins.py
@@ -155,10 +155,10 @@ class pluginsTypeMenu(menu):
         else:
             return self
 
-    def _enablePlugins(self, list):
+    def _enablePlugins(self, lst):
         enabled = copy.copy(self._w4af.plugins.get_enabled_plugins(self._name))
 
-        for plugin in list:
+        for plugin in lst:
             if plugin == '':
                 continue
             if plugin.startswith('!'):
@@ -176,7 +176,10 @@ class pluginsTypeMenu(menu):
                 elif plugin in enabled:
                     enabled.remove(plugin)
             elif plugin == 'all':
-                enabled = list(self._plugins.keys())
+                if isinstance(self._plugins, list):
+                    enabled = self._plugins
+                else:
+                    enabled = list(self._plugins.keys())
             elif plugin not in enabled:
                 enabled.append(plugin)
 


### PR DESCRIPTION
on the console executable, I tried to run ```plugins audit all``` which raised an error about how self._plugins doesn't have attribute to keys which is because self._plugins isn't always a dictionary. This error was suppressed by adding the isinstance condition. 

I also changed a variable name from ```list``` to ```lst``` becuase it was causing an error when calling ```isinstance(self._plugins, list)``` because it didn't see ```list``` as a datatype